### PR TITLE
Frequency band presence values constrained to 0-1 range.

### DIFF
--- a/rtmaii/analysis/frequency.py
+++ b/rtmaii/analysis/frequency.py
@@ -1,28 +1,34 @@
+"""
+    Frequency analysis module.
+    - Analyses parts of the frequency spectrum, including the presence of each band.
+"""
 # INPUTS spectrum
 # OUTPUTS frequency_bands
-# TODO: Comment the shit out of this.
 
-def remove_noise(spectrum, noise_level):
-    """ Remove any frequencies with an amplitude under the noise_level param when calculating balance """
+def remove_noise(spectrum: list, noise_level: float):
+    """ Remove any frequencies with an amplitude under the noise_level param when calculating balance. """
     return list(map(lambda amp: 0 if amp < noise_level else amp, spectrum))
 
-def normalize_dict(dictionary):
-    """ Constrain dictionary values to continous range 0-1. """
-    dict_sum = sum(dictionary.values())
-    norm = { key: float(value)/dict_sum for key, value in dictionary.items() }
-    return norm
+def normalize_dict(dictionary: dict, dict_sum: float):
+    """ Constrain dictionary values to continous range 0-1 based on the dictionary sum given.
 
-def frequency_bands(spectrum, bands):
+        **Args**:
+            - dictionary: the dictionary to be normalized.
+            - dict_sum: the sum value to normalize with.
+    """
+    return { key: float(value)/dict_sum for key, value in dictionary.items() }
+
+
+def frequency_bands(spectrum: list, bands: dict):
     """
         Creates a Dictionary of the amplitude balance between each input frequency band.
-        The sum of all values adds up to 1.
     """
     filtered_spectrum = remove_noise(spectrum, 0.5)
 
     band_presence = {band: sum(filtered_spectrum[int(values[0]):int(values[1])])
                      for band, values in bands.items()}
 
-    normalized_presence = normalize_dict(band_presence)
+    normalized_presence = normalize_dict(band_presence, sum(filtered_spectrum))
 
     return normalized_presence
 

--- a/rtmaii/analysis/frequency.py
+++ b/rtmaii/analysis/frequency.py
@@ -19,16 +19,27 @@ def normalize_dict(dictionary: dict, dict_sum: float):
     return { key: float(value)/dict_sum for key, value in dictionary.items() }
 
 
+def get_band_power(spectrum: list, bands: dict):
+    """ Get the summed power of each frequency range provided by bands.
+
+        **Args**:
+            - spectrum: the spectrum to be summed against.
+            - bands: the bands to sum powers of.
+    """
+    return {band: sum(spectrum[int(values[0]):int(values[1])])
+                     for band, values in bands.items()}
+
 def frequency_bands(spectrum: list, bands: dict):
     """
         Creates a Dictionary of the amplitude balance between each input frequency band.
+
+        **Args**:
+            - spectrum: the spectrum to analyse.
+            - bands: the band ranges to find the presence of.
     """
     filtered_spectrum = remove_noise(spectrum, 0.5)
-
-    band_presence = {band: sum(filtered_spectrum[int(values[0]):int(values[1])])
-                     for band, values in bands.items()}
-
-    normalized_presence = normalize_dict(band_presence, sum(filtered_spectrum))
+    band_power = get_band_power(spectrum, bands)
+    normalized_presence = normalize_dict(band_power, sum(filtered_spectrum))
 
     return normalized_presence
 

--- a/rtmaii/analysis/frequency.py
+++ b/rtmaii/analysis/frequency.py
@@ -6,9 +6,11 @@ def remove_noise(spectrum, noise_level):
     """ Remove any frequencies with an amplitude under the noise_level param when calculating balance """
     return list(map(lambda amp: 0 if amp < noise_level else amp, spectrum))
 
-def constrain_bands(bands):
-    """ Constrain Frequency bands to sum to 1 """
-    pass
+def normalize_dict(dictionary):
+    """ Constrain dictionary values to continous range 0-1. """
+    dict_sum = sum(dictionary.values())
+    norm = { key: float(value)/dict_sum for key, value in dictionary.items() }
+    return norm
 
 def frequency_bands(spectrum, bands):
     """
@@ -16,12 +18,13 @@ def frequency_bands(spectrum, bands):
         The sum of all values adds up to 1.
     """
     filtered_spectrum = remove_noise(spectrum, 0.5)
-    band_width = 19980 # Should be configurable
-    # TODO: Scale values to add up to 1, remove noise i.e. frequencies with minute amplitudes
+
     band_presence = {band: sum(filtered_spectrum[int(values[0]):int(values[1])])
                      for band, values in bands.items()}
-    return band_presence
+
+    normalized_presence = normalize_dict(band_presence)
+
+    return normalized_presence
 
 # NOTE: Could analyse other frequencies in spectrum, find overtones and harmonics
 # Default configuration should be bass, lows, highs
-# Possible add tracker for a set frequency yourself. configurable bands.

--- a/rtmaii/test/basic/test_basic_bands.py
+++ b/rtmaii/test/basic/test_basic_bands.py
@@ -2,21 +2,44 @@
     Test file
     Sine Wave, Sawtooth and Square
 '''
-import logging
 import unittest
-from numpy import sin, pi, arange
-from rtmaii.analysis import pitch
-from rtmaii.analysis import spectral
-from numpy import fft
-
+from numpy import arange
+from rtmaii.analysis import frequency
 
 class TestSuite(unittest.TestCase):
     '''
         Test Suite for the bands module.
     '''
 
-    def test_basic_Bands(self):
-        """ Test that the zero-crossings algorithm can detect the correct pitch for a basic sine wave. """
-        self.assertEqual(1, 1)
+    def setUp(self):
+        """ Perform setup of initial parameters. """
+        self.band_sum = 10000
+        self.bands = 10230
+        self.spectrum = arange(0, 100, 1) # Create 100 values increasing by 1 at each step.
+        self.bands = {'0.1': 10, '0.2': 20, '0.3': 30, '1': 100} # key value where key == expected value after normalization.
+        self.bands_sum = 100 # Sum to compare normalized values against.
 
+    def test_noise_removal(self):
+        """ Remove frequencies below amplitude of 11. Keep amplitudes above. """
+        noiseless_spectrum = frequency.remove_noise(self.spectrum, 11)
+        for i in range(10):
+            self.assertEqual(noiseless_spectrum[i], 0)
+        for i in range(11, len(self.spectrum)):
+            self.assertNotEqual(noiseless_spectrum[i], 0)
+
+    def test_normalization(self):
+        """ Test that the values are normalized as expected. """
+        normalized_dictionary = frequency.normalize_dict(self.bands, self.bands_sum)
+        for key, value in normalized_dictionary.items():
+            self.assertEqual(float(key), value)
+
+    def test_band_power(self):
+        """ Test that a given frequency range is summed correctly. """
+        power = frequency.get_band_power(self.spectrum, {'full_range': [0, len(self.spectrum)]})
+        self.assertEqual(power['full_range'], sum(self.spectrum))
+
+    def test_frequency_bands(self):
+        """ End-to-end test of retrieiving the presence of a frequency bands. """
+        bands = frequency.frequency_bands(self.spectrum, {'full_range': [0, len(self.spectrum)]})
+        self.assertEqual(bands['full_range'], 1)
 


### PR DESCRIPTION
The values generated when analysing the frequency bands of a spectrum will now be based on the summed power of the frequency range i.e. (200hz-500hz) divided by the sum power of the entire frequency range i.e. (22050hz).

In debugger view.
![image](https://user-images.githubusercontent.com/29373199/36076090-c093f504-0f4f-11e8-9a60-75adad0e79ad.png)

The reasoning for normalizing the powers to a range is because the maximum power of a frequency spectrum can vary quite dramatically, so this allows the data to be reasoned with more.
