### PR TITLE
Fix end of sample error 'setting an array element with a sequence'

### DIFF
--- a/rtmaii/configuration.py
+++ b/rtmaii/configuration.py
@@ -50,6 +50,7 @@ class Config(object):
             },
             "fft_resolution": 20480,
             "pitch_algorithm": "hps",
+            "frames_per_sample": 1024,
         }
 
         self.settings = self.defaults


### PR DESCRIPTION
When the analysis reaches it's inevitable end with wave files, you will have noticed an error is thrown and everything crashes... Not fun!

This was because pyaudio will continue to read the signal data even though it might not equate to 1024 frames, which a lot of our library currently relies on.

This caused an issue when averaging channel signals, as they sometimes had different lengths causing the error below to be thrown and crash the library.
![POS](https://user-images.githubusercontent.com/29373199/36380947-f5dd4dd2-157b-11e8-9ee6-d94ce8aa2d68.png)

I now zero pad each channel's signals to be a length defined in the config 'frames_per_sample', which is the chunk length we currently use.. (Considering not having this in the config module due to the fragility of components relying on it.)

The signal graph will now look like this at the end of analysis.
![image](https://user-images.githubusercontent.com/29373199/36381414-629b7cd6-157d-11e8-97d5-c14a1423ea2b.png)
