### PR TITLE
Threads will continue to wait for data instead of being killed at end of analysis.

### DIFF
--- a/rtmaii/coordinator.py
+++ b/rtmaii/coordinator.py
@@ -69,12 +69,6 @@ class Coordinator(BaseCoordinator):
 
         while True:
             data = self.queue.get()
-
-            if data is None:
-                self.message_peers(None)
-                LOGGER.info('Coordinator Finishing Up.')
-                break # No more data so cleanup and end thread.
-
             channel_signals = []
 
             for channel in range(channels):
@@ -98,11 +92,6 @@ class Coordinator(BaseCoordinator):
 
         while True:
             data = self.queue.get()
-
-            if data is None:
-                self.message_peers(None)
-                LOGGER.info('Coordinator Finishing Up.')
-                break # No more data so cleanup and end thread.
 
             for channel in range(1, channels + 1):
                 channel_signal = data[channel::channels]
@@ -156,10 +145,6 @@ class FrequencyCoordinator(BaseCoordinator):
 
         while start_analysis:
             data = self.queue.get()
-            if data is None:
-                LOGGER.info('{} Frequency Coordinator finishing up'.format(self.channel_id))
-                self.message_peers(None)
-                break # No more data so cleanup and end thread
             signal = signal[1024:]
             signal.extend(data)
             self.message_peers(signal)
@@ -200,10 +185,6 @@ class SpectrumCoordinator(BaseCoordinator):
     def run(self):
         while True:
             signal = self.queue.get()
-            if signal is None:
-                self.message_peers(None)
-                break
-
             frequency_spectrum = spectral.spectrum(signal, self.window, self.filter)
             self.message_peers(frequency_spectrum)
             dispatcher.send(signal='spectrum', sender=self.channel_id, data=frequency_spectrum)
@@ -217,9 +198,6 @@ class SpectrogramCoordinator(BaseCoordinator):
         spectrogram_resolution = 10
         while True:
             fft = self.queue.get()
-            if fft is None:
-                self.message_peers(None)
-                break
             ffts.append(fft)
             ffts = ffts[-spectrogram_resolution:]
 

--- a/rtmaii/rtmaii.py
+++ b/rtmaii/rtmaii.py
@@ -57,10 +57,7 @@ class Rtmaii(object):
         data = fromstring(
             self.waveform.readframes(frame_count) if hasattr(self, 'waveform') else in_data,
             dtype=int16)
-
         self.coordinator.queue.put(data)
-        if status == 4: # Push finish request to coordinator when stream has ended.
-            self.coordinator.queue.put(None)
         return (data, pyaudio.paContinue)
 
     def is_active(self):
@@ -85,8 +82,6 @@ class Rtmaii(object):
     def stop(self):
         """ Stop the stream & close the track (if set). """
         self.stream.stop_stream()
-        self.stream.close()
-        self.coordinator.queue.put(None)
         if hasattr(self, 'waveform'):
             self.waveform.close()
 

--- a/rtmaii/rtmaii.py
+++ b/rtmaii/rtmaii.py
@@ -74,6 +74,9 @@ class Rtmaii(object):
         pyaudio_settings = self.config.get_config('pyaudio_settings')
         pyaudio_settings['stream_callback'] = self.__stream_callback__
 
+        if hasattr(self, 'waveform'):
+            self.waveform.setpos(0) # Reset wave file to initial position.
+
         self.stream = self.audio.open(**pyaudio_settings)
         self.stream.start_stream()
 

--- a/rtmaii/worker.py
+++ b/rtmaii/worker.py
@@ -44,9 +44,6 @@ class BandsWorker(Worker):
     def run(self):
         while True:
             spectrum = self.queue.get()
-            if spectrum is None:
-                break # No more data so cleanup and end thread.
-
             frequency_bands = frequency.frequency_bands(abs(spectrum), self.bands_of_interest)
             dispatcher.send(signal='bands', sender=self.channel_id, data=frequency_bands) #TODO: Move to a locator.
 
@@ -64,9 +61,6 @@ class ZeroCrossingWorker(PitchWorker):
     def run(self):
         while True:
             signal = self.queue.get()
-            if signal is None:
-                break # No more data so cleanup and end thread.
-
             estimated_pitch = pitch.pitch_from_zero_crossings(signal, self.sampling_rate)
             dispatcher.send(signal='pitch', sender=self.channel_id, data=estimated_pitch)
             self.analyse_key(estimated_pitch)
@@ -85,9 +79,6 @@ class AutoCorrelationWorker(PitchWorker):
     def run(self):
         while True:
             signal = self.queue.get()
-            if signal is None:
-                break # No more data so cleanup and end thread.
-
             convolved_spectrum = spectral.convolve_spectrum(signal)
             estimated_pitch = pitch.pitch_from_auto_correlation(convolved_spectrum, self.sampling_rate)
             dispatcher.send(signal='pitch', sender=self.channel_id, data=estimated_pitch)
@@ -108,9 +99,6 @@ class HPSWorker(PitchWorker):
     def run(self):
         while True:
             spectrum = self.queue.get()
-            if spectrum is None:
-                break # No more data so cleanup and end thread.
-
             estimated_pitch = pitch.pitch_from_hps(spectrum, self.sampling_rate, 7)
             dispatcher.send(signal='pitch', sender=self.channel_id, data=estimated_pitch)
             self.analyse_key(estimated_pitch)
@@ -129,9 +117,6 @@ class FFTWorker(PitchWorker):
     def run(self):
         while True:
             spectrum = self.queue.get()
-            if spectrum is None:
-                break # No more data so cleanup and end thread.
-
             estimated_pitch = pitch.pitch_from_fft(spectrum, self.sampling_rate)
             dispatcher.send(signal='pitch', sender=self.channel_id, data=estimated_pitch)
             self.analyse_key(estimated_pitch)


### PR DESCRIPTION
Originally when the analysis was stopped, each thread would be messaged with 'none' to allow themselves to be cleaned up. 

However, I don't see the point of cleaning up the threads unless a user no longer needs to do any analysis, by keeping the threads awake and waiting to process more data a user can easily swap to another song or restart the analysis. (Avoiding re-initializing the entire hierarchy).