### PR TITLE
Debugger performance improvements

### DIFF
--- a/debugger.py
+++ b/debugger.py
@@ -8,7 +8,6 @@
     TODO: genre labels
 
 """
-import time
 import threading
 from scipy.signal import resample
 from rtmaii import rtmaii # Replace with just import rtmaii in actual implementation.
@@ -143,7 +142,7 @@ class Debugger(tk.Tk):
         SignalPlotter(self.listener, self.signal_plot, self.signal_line)
 
         # --- SPECTRUM GRAPH --- #
-        self.frequencies = arange(SPECTRUM_LENGTH // DOWNSAMPLE_RATE)/(CHUNK_LENGTH/SAMPLING_RATE)/2 # Possible range of frequencies
+        self.frequencies = arange(0, SPECTRUM_LENGTH, DOWNSAMPLE_RATE) / (CHUNK_LENGTH/SAMPLING_RATE)/2 # Possible range of frequencies
         spectrum_frame = Figure(figsize=(8, 4), dpi=100)
         self.spectrum_plot = spectrum_frame.add_subplot(111)
         self.spectrum_canvas = FigureCanvasTkAgg(spectrum_frame, left_frame)
@@ -209,16 +208,12 @@ class Debugger(tk.Tk):
     def update(self):
         """ Update UI every FRAME_DELAY milliseconds """
         # --- UPDATE GRAPHS --- #
-        sigtime = time.time()
         self.signal_canvas.restore_region(self.signal_background)
         self.signal_plot.draw_artist(self.signal_line)
         self.signal_canvas.blit(self.signal_plot.bbox)
-        print('{} sig'.format(time.time() - sigtime))
-        spectime = time.time()
         self.spectrum_canvas.restore_region(self.signal_background)
         self.spectrum_plot.draw_artist(self.spectrum_line)
         self.spectrum_canvas.blit(self.spectrum_plot.bbox)
-        print('{} spec'.format(time.time() - spectime))
         # --- UPDATE LABELS --- #
         self.pitch.set("{0:.2f}".format(self.listener.get_item('pitch')))
         self.key.set(self.listener.get_item('key'))

--- a/rtmaii/analysis/spectral.py
+++ b/rtmaii/analysis/spectral.py
@@ -47,11 +47,11 @@ def spectrum_transform(signal: list):
     """ Performs FFT on input signal """
     signal_length = len(signal)
     normalized_spectrum = fft(signal) / signal_length # Normalization
-    return abs(normalized_spectrum[:signal_length // 2]) # Only need half of fft
+    return normalized_spectrum[:signal_length // 2:] # Only need half of fft output.
 
 def spectrum(signal: list,
              window: list,
-             bp_filter: dict):
+             bp_filter: dict = None):
     """ Return the frequency spectrum of an input signal.
 
     **Args**
@@ -61,7 +61,7 @@ def spectrum(signal: list,
              In the form of {'numerator': list, 'denominator': list}
     """
     windowed_signal = signal * window
-    filtered_signal = band_pass_filter(windowed_signal, bp_filter['numerator'], bp_filter['denominator'])
+    filtered_signal = windowed_signal if bp_filter is None else band_pass_filter(windowed_signal, bp_filter['numerator'], bp_filter['denominator'])
     frequency_spectrum = spectrum_transform(filtered_signal)
     return frequency_spectrum
 

--- a/rtmaii/configuration.py
+++ b/rtmaii/configuration.py
@@ -48,7 +48,7 @@ class Config(object):
                 "beat": True,
                 "bands": True
             },
-            "fft_resolution": 20480,
+            "frequency_samples": 20, # Amount of samples to take before performing pitch tasks (Higher = More accurate, but more computationally expensive.)
             "pitch_algorithm": "auto-correlation",
             "frames_per_sample": 1024,
         }

--- a/rtmaii/coordinator.py
+++ b/rtmaii/coordinator.py
@@ -122,13 +122,13 @@ class FrequencyCoordinator(Coordinator):
     def run(self):
         """ Extend signal data to configured resolution before transmitting to peers. """
 
-        fft_resolution = self.config.get_config('fft_resolution')
+        frequency_resolution = self.config.get_config('frequency_samples') * self.config.get_config('frames_per_sample')
         start_analysis = False
         signal = []
 
         while not start_analysis:
             signal.extend(self.queue.get())
-            if len(signal) >= fft_resolution:
+            if len(signal) >= frequency_resolution:
                 start_analysis = True
 
         while start_analysis:
@@ -150,11 +150,12 @@ class SpectrumCoordinator(Coordinator):
     """
     def __init__(self, config: object, peer_list: list, channel_id: int):
         Coordinator.__init__(self, config, peer_list)
-        fft_resolution = self.config.get_config('fft_resolution')
+        frequency_samples = config.get_config('frequency_samples')
+        frames_per_sample = config.get_config('frames_per_sample')
 
         self.sampling_rate = config.get_config('sampling_rate')
         self.channel_id = channel_id
-        self.window = spectral.new_window(fft_resolution, 'blackmanharris')
+        self.window = spectral.new_window(frequency_samples * frames_per_sample, 'hanning')
         self.filter = spectral.butter_bandpass(10, 20000, self.sampling_rate, 5)
 
     def run(self):

--- a/rtmaii/hierarchy.py
+++ b/rtmaii/hierarchy.py
@@ -40,7 +40,7 @@ def new_hierarchy(config: object):
             elif algorithm == 'fft':
                 spectrum_list.append(new_worker('FFT', {'sampling_rate' : sampling_rate, 'channel_id': channel_id}))
             else:
-                spectrum_list.append(new_worker('AutoCorrelation', {'sampling_rate' : sampling_rate, 'channel_id': channel_id}))
+                freq_list.append(new_worker('AutoCorrelation', {'sampling_rate' : sampling_rate, 'channel_id': channel_id}))
 
         if tasks['genre']:
             # TODO: CREATE NECESSARY genre detection worker here.


### PR DESCRIPTION
The debugger plotting was horrifically slow causing it to lag beyond belief..

Original time to plot both graphs:
![image](https://user-images.githubusercontent.com/29373199/36630238-1f1a6170-195b-11e8-8460-465c0665739f.png)

Updated time to plot both graphs:
![image](https://user-images.githubusercontent.com/29373199/36630267-7f13a6fe-195b-11e8-9c8d-f5363d407c95.png)

Matplotlib doesn't seem like the best choice for a realtime debugger, however as this is only an extension of our library and more of example for demoing, this isn't too much of an issue.

We can always talk about this in the report, and that if we had more time a more robust solution would be offered. As other UIs such as Pyqtgraph are great for realtime plotting, but require additional setup. I chose Matplotlib alongside Tkinter as they can easily be installed out of the box with Python.

Onto the improvements.
- The signal/spectrum plots now have personal threads that will update their y data with the latest values from the Listener. (This takes some of the strain off the main GUI thread.)
- The plots now use special matplotlib methods that will only update the lines on the graph, instead of redrawing the entire graph. (Which led to some plots taking over a second each).
- The data that is being plotted is now being subsampled using scipy, this reduces the resolution of the plotted graphs, but drastically improves the plotting of the spectrum (Which originally plotted 22000 data points).

New Settings:
- Downsample_Rate : denonimator to divide the resolution of each graph by, increasing this helps to speed up plotting substanially as it reduces the amount of data to plot proportionally to the rate set.