### PR TITLE
Fixed frequency bands not corresponding to actual bin locations.

### DIFF
--- a/rtmaii/analysis/frequency.py
+++ b/rtmaii/analysis/frequency.py
@@ -5,6 +5,9 @@
 # INPUTS spectrum
 # OUTPUTS frequency_bands
 
+from scipy.fftpack import fftfreq
+from numpy import argmin, abs
+
 def remove_noise(spectrum: list, noise_level: float):
     """ Remove any frequencies with an amplitude under the noise_level param when calculating balance. """
     return list(map(lambda amp: 0 if amp < noise_level else amp, spectrum))
@@ -29,7 +32,7 @@ def get_band_power(spectrum: list, bands: dict):
     return {band: sum(spectrum[int(values[0]):int(values[1])])
                      for band, values in bands.items()}
 
-def frequency_bands(spectrum: list, bands: dict):
+def frequency_bands(spectrum: list, bands: dict, sampling_rate: int):
     """
         Creates a Dictionary of the amplitude balance between each input frequency band.
 
@@ -37,11 +40,25 @@ def frequency_bands(spectrum: list, bands: dict):
             - spectrum: the spectrum to analyse.
             - bands: the band ranges to find the presence of.
     """
+    matched_bands = frequency_bands_to_bins(spectrum, bands, sampling_rate)
     filtered_spectrum = remove_noise(spectrum, 0.5)
-    band_power = get_band_power(spectrum, bands)
+    band_power = get_band_power(spectrum, matched_bands)
     normalized_presence = normalize_dict(band_power, sum(filtered_spectrum))
 
     return normalized_presence
+
+def frequency_bands_to_bins(spectrum: list, bands: dict, sampling_rate: int):
+    """
+        In order to correctly analyse frequency bands, we need to first find the equivalent frequency bin locations.
+    """
+    bins = fftfreq(len(spectrum))[:len(spectrum) // 2] * sampling_rate
+    return {band: [find_nearest_bin(bins, values[0]), find_nearest_bin(bins, values[1])] for band, values in bands.items()}
+
+def find_nearest_bin(bins: list, target: int):
+    """
+        test
+    """
+    return (abs(bins-target)).argmin()
 
 # NOTE: Could analyse other frequencies in spectrum, find overtones and harmonics
 # Default configuration should be bass, lows, highs

--- a/rtmaii/analysis/frequency.py
+++ b/rtmaii/analysis/frequency.py
@@ -51,7 +51,7 @@ def frequency_bands_to_bins(spectrum: list, bands: dict, sampling_rate: int):
     """
         In order to correctly analyse frequency bands, we need to first find the equivalent frequency bin locations.
     """
-    bins = fftfreq(len(spectrum))[:len(spectrum) // 2] * sampling_rate
+    bins = fftfreq(len(spectrum) * 2)[:len(spectrum)] * sampling_rate
     return {band: [find_nearest_bin(bins, values[0]), find_nearest_bin(bins, values[1])] for band, values in bands.items()}
 
 def find_nearest_bin(bins: list, target: int):

--- a/rtmaii/hierarchy.py
+++ b/rtmaii/hierarchy.py
@@ -49,7 +49,7 @@ def new_hierarchy(config: object):
 
         if tasks['bands']:
             bands_of_interest = config.get_config('bands')
-            spectrum_list.append(new_worker('Bands', {'bands_of_interest' : bands_of_interest, 'channel_id': channel_id}))
+            spectrum_list.append(new_worker('Bands', {'bands_of_interest' : bands_of_interest, 'sampling_rate' : sampling_rate, 'channel_id': channel_id}))
 
 
         #--- Root Nodes (Coordinators) - Created last in order so that peers can be injected. ---#

--- a/rtmaii/test/basic/test_basic_bands.py
+++ b/rtmaii/test/basic/test_basic_bands.py
@@ -3,7 +3,7 @@
     Sine Wave, Sawtooth and Square
 '''
 import unittest
-from numpy import arange
+from numpy import arange, zeros
 from rtmaii.analysis import frequency
 
 class TestSuite(unittest.TestCase):
@@ -16,6 +16,7 @@ class TestSuite(unittest.TestCase):
         self.band_sum = 10000
         self.interested_bands = {'low': [0 , 10], 'med': [10, 70], 'high': [70, 100]}
         self.spectrum = arange(0, 100, 1) # Create 100 values increasing by 1 at each step.
+        self.spectrum_len = len(self.spectrum)
         self.bands = {'0.1': 10, '0.2': 20, '0.3': 30, '1': 100} # key value where key == expected value after normalization.
         self.bands_sum = 100 # Sum to compare normalized values against.
 
@@ -24,7 +25,7 @@ class TestSuite(unittest.TestCase):
         noiseless_spectrum = frequency.remove_noise(self.spectrum, 11)
         for i in range(10):
             self.assertEqual(noiseless_spectrum[i], 0)
-        for i in range(11, len(self.spectrum)):
+        for i in range(11, self.spectrum_len):
             self.assertNotEqual(noiseless_spectrum[i], 0)
 
     def test_normalization(self):
@@ -35,7 +36,7 @@ class TestSuite(unittest.TestCase):
 
     def test_band_power(self):
         """ Test that a given frequency range is summed correctly. """
-        power = frequency.get_band_power(self.spectrum, {'full_range': [0, len(self.spectrum)]})
+        power = frequency.get_band_power(self.spectrum, {'full_range': [0, self.spectrum_len]})
         self.assertEqual(power['full_range'], sum(self.spectrum))
 
     def test_multiple_band_power(self):
@@ -46,6 +47,13 @@ class TestSuite(unittest.TestCase):
 
     def test_frequency_bands(self):
         """ End-to-end test of retrieiving the presence of a frequency bands. """
-        bands = frequency.frequency_bands(self.spectrum, {'full_range': [0, len(self.spectrum)]})
+        spectrum = zeros(100) # Start with empty array
+        spectrum[2] = 100 # Set low band to have all the power.
+        bands = frequency.frequency_bands(spectrum, {'full_range': [2, 3]}, len(spectrum) * 2)
         self.assertEqual(bands['full_range'], 1)
 
+    def test_frequency_bands_to_bins(self):
+        """ Tests that the frequency bins points are correctly found. """
+        spectrum = arange(0, 102, 1)
+        bands = frequency.frequency_bands_to_bins(spectrum, {'full_range': [0, 100]}, len(spectrum) * 2)
+        self.assertEqual({'full_range': [0, 100]}, bands)

--- a/rtmaii/worker.py
+++ b/rtmaii/worker.py
@@ -28,14 +28,15 @@ class BandsWorker(Worker):
             - `bands_of_interest`: dictionary of frequency bands to analyse.
             - `channel_id`: id of channel being analysed.
     """
-    def __init__(self, bands_of_interest: dict, channel_id: int):
+    def __init__(self, bands_of_interest: dict, sampling_rate: int, channel_id: int):
         Worker.__init__(self, channel_id)
         self.bands_of_interest = bands_of_interest
+        self.sampling_rate = sampling_rate
 
     def run(self):
         while True:
             spectrum = self.queue.get()
-            frequency_bands = frequency.frequency_bands(abs(spectrum), self.bands_of_interest)
+            frequency_bands = frequency.frequency_bands(abs(spectrum), self.bands_of_interest, self.sampling_rate)
             dispatcher.send(signal='bands', sender=self.channel_id, data=frequency_bands) #TODO: Move to a locator.
 
 class Key(object):


### PR DESCRIPTION
So i was a bit of an idiot and had originally believed the length of data returned from the spectrum method would be equal to the full range of frequencies.

I was wrong!!

Luckily the main module that operated under this impression, was the frequency bands tasks, this PR fixes this issue and should now take into account a reduced frequency resolution.

As with all real-time tasks to do with frequency, if you want a more accurate reading increase your resolution at the trade-off of speed.