### PR TITLE
Cleanup pitch methods

### DIFF
--- a/debugger.py
+++ b/debugger.py
@@ -381,8 +381,8 @@ class Debugger(tk.Tk):
     def setup_key_label(self, frame):
         # --- KEY LABEL --- #
         self.key = tk.StringVar()
-        key_label = tk.Label(frame, text=str('Key:'), bg=ACCENT_COLOR, foreground=TEXT_COLOR, font=(None, FONT_SIZE))
-        key_label.place(x=100, y=0, height=30, width=40)
+        key_label = tk.Label(frame, text=str('Root Note:'), bg=ACCENT_COLOR, foreground=TEXT_COLOR, font=(None, FONT_SIZE))
+        key_label.place(x=40, y=0, height=30, width=110)
         key_value = tk.Label(frame, textvariable=self.key, bg=ACCENT_COLOR, foreground=TEXT_COLOR, font=(None, FONT_SIZE))
         key_value.place(x=140, y=0, height=30, width=80)
 

--- a/rtmaii/analysis/pitch.py
+++ b/rtmaii/analysis/pitch.py
@@ -104,9 +104,9 @@ def pitch_from_hps(spectrum: list, sampling_rate: int, max_harmonics: int):
 
     pitch = argmax(harmonic_spectrum)
 
-    interpolated_pitch = interpolate_peak(harmonic_spectrum, pitch)
+    #interpolated_pitch = interpolate_peak(harmonic_spectrum, pitch)
 
-    return sampling_rate * interpolated_pitch / (len(spectrum) * 2)
+    return sampling_rate * pitch / (len(spectrum) * 2)
 
 def interpolate_peak(spectrum: list, peak: int):
     """ Uses quadratic interpolation of spectral peaks to get a better estimate of the peak.

--- a/rtmaii/analysis/pitch.py
+++ b/rtmaii/analysis/pitch.py
@@ -14,7 +14,8 @@
         * Look into other areas i.e. harmonic product spectrum.
         * Finish comments and documentation.
 """
-from numpy import argmax, mean, diff, arange
+from numpy import argmax, mean, diff, arange, copy
+from scipy.signal import decimate
 
 def pitch_from_fft(spectrum: list, sampling_rate: int):
     """ Estimate pitch from the frequency spectrum.
@@ -33,11 +34,10 @@ def pitch_from_fft(spectrum: list, sampling_rate: int):
 
     """
     basic_frequency = argmax(spectrum)
-    estimated_frequency = interpolate_peak(abs(spectrum), basic_frequency)
-    return sampling_rate * basic_frequency / len(spectrum) / 2
-    #TODO: Validate why / 2 is needed, probably due to halving the spectrum initially in spectral module.
+    estimated_frequency = interpolate_peak(spectrum, basic_frequency)
+    return sampling_rate * basic_frequency / (len(spectrum) * 2)
 
-def pitch_from_auto_correlation(convolved_spectrum: list, sampling_rate: int):
+def pitch_from_auto_correlation(convolved_signal: list, sampling_rate: int):
     """ Estimate pitch using the autocorrelation method.
 
         **Args**:
@@ -54,12 +54,12 @@ def pitch_from_auto_correlation(convolved_spectrum: list, sampling_rate: int):
 
     """
 
-    spectrum_distances = diff(convolved_spectrum)
+    signal_distances = diff(convolved_signal)
     first_low_point = next(
-        i for i, _ in enumerate(spectrum_distances) if spectrum_distances[i] > 0
+        i for i, _ in enumerate(signal_distances) if signal_distances[i] > 0
     ) # Finds first rising edge
-    peak = argmax(convolved_spectrum[first_low_point:]) + first_low_point
-    interpolated_peak = interpolate_peak(convolved_spectrum, peak)
+    peak = argmax(convolved_signal[first_low_point:]) + first_low_point
+    interpolated_peak = interpolate_peak(convolved_signal, peak)
     return sampling_rate / peak
 
 def pitch_from_zero_crossings(signal: list, sampling_rate: int):
@@ -95,17 +95,18 @@ def pitch_from_hps(spectrum: list, sampling_rate: int, max_harmonics: int):
             - max_framonics the sampling rate of the audio source.
 
     """
-    harmonic_spectrum = abs(spectrum) # Keep positive values
+    harmonic_spectrum = spectrum
 
     for harmonic_level in range(2, max_harmonics):
-        downsampled_spectrum = harmonic_spectrum [::harmonic_level]
-        harmonic_spectrum = harmonic_spectrum [:len(downsampled_spectrum)]
-        pitch = argmax(harmonic_spectrum)
-        harmonic_spectrum *= downsampled_spectrum
+        spectrum_c = harmonic_spectrum.copy() # Shallow copy, allowing values to be changed in original array.
+        downsampled_spectrum = decimate(spectrum, harmonic_level) # Downsample using anti-aliasing, = better results.
+        spectrum_c[:len(downsampled_spectrum)] *= downsampled_spectrum # Amplify any frequencies based on harmnonics.
 
-    # interpolated_pitch = interpolate_peak(harmonic_spectrum, pitch)
+    pitch = argmax(harmonic_spectrum)
 
-    return sampling_rate * pitch / len(spectrum)
+    interpolated_pitch = interpolate_peak(harmonic_spectrum, pitch)
+
+    return sampling_rate * interpolated_pitch / (len(spectrum) * 2)
 
 def interpolate_peak(spectrum: list, peak: int):
     """ Uses quadratic interpolation of spectral peaks to get a better estimate of the peak.

--- a/rtmaii/analysis/spectral.py
+++ b/rtmaii/analysis/spectral.py
@@ -38,16 +38,16 @@ def new_window(N: int, window: str):
     window = get_window(window, N, True)
     return window
 
-def convolve_spectrum(signal: list):
+def convolve_signal(signal: list):
     """ Apply convolution to the input signal. """
     convol = fftconvolve(signal, signal[::-1], mode='full')
-    return convol[len(convol) // 2:] # Split bin in half removing negatives.
+    return convol[len(convol) // 2:] # Split bin in half removing negative lags.
 
 def spectrum_transform(signal: list):
-    """ Performs FFT on input signal """
+    """ Performs FFT on input signal. """
     signal_length = len(signal)
     normalized_spectrum = fft(signal) / signal_length # Normalization
-    return normalized_spectrum[:signal_length // 2:] # Only need half of fft output.
+    return normalized_spectrum[:signal_length // 2] # Only need half of fft output.
 
 def spectrum(signal: list,
              window: list,
@@ -64,8 +64,3 @@ def spectrum(signal: list,
     filtered_signal = windowed_signal if bp_filter is None else band_pass_filter(windowed_signal, bp_filter['numerator'], bp_filter['denominator'])
     frequency_spectrum = spectrum_transform(filtered_signal)
     return frequency_spectrum
-
-
-def spectro(signal, sampling_rate):
-    """ Basic form of creating a spectrogram, can create our own using FFT bins """
-    return spectrogram(signal, sampling_rate)

--- a/rtmaii/test/basic/test_basic_pitch.py
+++ b/rtmaii/test/basic/test_basic_pitch.py
@@ -40,4 +40,4 @@ class TestSuite(unittest.TestCase):
 
     def test_basic_HPS(self):
         """ Test that the zero-crossings algorithm can detect the correct pitch for a basic sine wave. """
-        # self.assertEqual(pitch.pitch_from_hps(self.frequency_spectrum, self.sampling_rate, 8), 5)
+        self.assertEqual(pitch.pitch_from_hps(self.frequency_spectrum, self.sampling_rate, 8), 5)

--- a/rtmaii/test/basic/test_basic_pitch.py
+++ b/rtmaii/test/basic/test_basic_pitch.py
@@ -24,7 +24,7 @@ class TestSuite(unittest.TestCase):
         self.bp_filter = spectral.butter_bandpass(1, 48, self.sampling_rate)
         self.window = spectral.new_window(len(self.sin_wave), 'blackmanharris')
         self.frequency_spectrum = spectral.spectrum(self.sin_wave, self.window, self.bp_filter)
-        self.convolved_spectrum = spectral.convolve_spectrum(self.sin_wave)
+        self.convolved_spectrum = spectral.convolve_signal(self.sin_wave)
 
     def test_basic_ZC(self):
         """ Test that the zero-crossings algorithm can detect the correct pitch for a basic sine wave. """

--- a/rtmaii/test/basic/test_basic_spectral.py
+++ b/rtmaii/test/basic/test_basic_spectral.py
@@ -32,7 +32,7 @@ class SpectralTestSuite(unittest.TestCase):
         self.window = spectral.new_window(self.sampling_rate, 'blackmanharris')
         self.bp_filter = spectral.butter_bandpass(1, 24, self.sampling_rate, 10)
         self.spectrum = spectral.spectrum(self.low_frequency, self.window, self.bp_filter)
-        self.conv_spectrum = spectral.convolve_spectrum(self.low_frequency)
+        self.conv_spectrum = spectral.convolve_signal(self.low_frequency)
 
         self.filter_cut_off = 0.006 # Maximum amplitude expected of filtered frequencies.
 

--- a/rtmaii/test/basic/test_basic_spectral.py
+++ b/rtmaii/test/basic/test_basic_spectral.py
@@ -32,7 +32,7 @@ class SpectralTestSuite(unittest.TestCase):
         self.window = spectral.new_window(self.sampling_rate, 'blackmanharris')
         self.bp_filter = spectral.butter_bandpass(1, 24, self.sampling_rate, 10)
         self.spectrum = spectral.spectrum(self.low_frequency, self.window, self.bp_filter)
-        self.conv_spectrum = spectral.convolve_signal(self.low_frequency)
+        self.conv_signal= spectral.convolve_signal(self.low_frequency)
 
         self.filter_cut_off = 0.006 # Maximum amplitude expected of filtered frequencies.
 
@@ -76,12 +76,12 @@ class SpectralTestSuite(unittest.TestCase):
 
     def test_conv_spectrum_length(self):
         """ Test length of generated convolved spectrums. Two spectrums so should be == sampling rate. """
-        self.assertEqual(len(self.conv_spectrum), self.sampling_rate)
+        self.assertEqual(len(self.conv_signal), self.sampling_rate)
 
     def test_conv_spectrum_value(self):
         """ As it's a basic sine wave the amplitude at the frequency location should be lowest.
             (Opposite to standard spectrum.)
         """
-        peak = self.conv_spectrum[5]
+        peak = self.conv_signal[5]
         for i in range(len(self.spectrum)):
-            self.assertLessEqual(peak, self.conv_spectrum[i])
+            self.assertLessEqual(peak, self.conv_signal[i])

--- a/rtmaii/test/test_advanced_spectral.py
+++ b/rtmaii/test/test_advanced_spectral.py
@@ -32,7 +32,7 @@ class SpectralTestSuite(unittest.TestCase):
         self.window = spectral.new_window(self.sampling_rate, 'blackmanharris')
         self.bp_filter = spectral.butter_bandpass(100, 20000, self.sampling_rate, 5)
         self.spectrum = spectral.spectrum(self.low_frequency, self.window, self.bp_filter)
-        self.conv_spectrum = spectral.convolve_spectrum(self.low_frequency)
+        self.conv_spectrum = spectral.convolve_signal(self.low_frequency)
 
         self.filter_cut_off = 0.006 # Maximum amplitude expected of filtered frequencies.
 

--- a/rtmaii/worker.py
+++ b/rtmaii/worker.py
@@ -124,8 +124,8 @@ class AutoCorrelationWorker(Worker, Key):
     def run(self):
         while True:
             signal = self.queue.get()
-            convolved_spectrum = spectral.convolve_spectrum(signal)
-            estimated_pitch = pitch.pitch_from_auto_correlation(convolved_spectrum, self.sampling_rate)
+            convolved_signal = spectral.convolve_signal(signal)
+            estimated_pitch = pitch.pitch_from_auto_correlation(convolved_signal, self.sampling_rate)
             dispatcher.send(signal='pitch', sender=self.channel_id, data=estimated_pitch)
             self.analyse_key(estimated_pitch, self.channel_id)
 


### PR DESCRIPTION
The harmonic product spectrum method should now work as expected, I was incorrectly overwriting the original values in the spectrum.

I've also removed some unnecessary absoluting on spectrum values, as I wasn't taking the correct half of the output spectrum.

Also the convoluted spectrum is actually just a shifted signal, so the name is completely wrong there and needed updated.