### PR TITLE
Benchmarking script

### DIFF
--- a/rtma-profiler.py
+++ b/rtma-profiler.py
@@ -1,3 +1,7 @@
+""" RTMA PROFILER/BENCHMARK
+
+    This module is a commandline script, which can run the library tasks in a sandboxed setting.
+"""
 from rtmaii import hierarchy, configuration
 from numpy import arange, sin, pi, ndarray, int16, frombuffer
 from pydispatch import dispatcher
@@ -5,7 +9,7 @@ import argparse
 import time
 import statistics
 
-parser = argparse.ArgumentParser(description="Benchmark each task based on configuration options used.")
+parser = argparse.ArgumentParser(description="Benchmark each task based on configuration options used in a sandbox simulation.")
 
 ## DEFAULTS ##
 BANDS = {
@@ -21,15 +25,19 @@ BANDS = {
 parser.add_argument("-b", "--bands", help="Frequency bands to analyse as a dictionary.", type=dict, default=BANDS)
 parser.add_argument("-s", "--samplingrate", help="Sampling rate in Hertz, i.e. 44100", type=int, default=44100)
 parser.add_argument("-f", "--framespersample", help="Frames per buffer sample, default is 1024", type=int, default=1024)
-parser.add_argument("-r", "--frequencyresolution", help="Frames per buffer sample, default is 1024", type=int, default=20480)
-parser.add_argument("-t", "--tasks", help="Frames per buffer sample, default is 1024", type=dict, default=1024)
-parser.add_argument("-p", "--pitchmethod", help="Frames per buffer sample, default is 1024", type=str, default='hps')
+parser.add_argument("-r", "--frequencyresolution", help="Resolution of signal before performing frequency analysis. Default is 20480.", type=int, default=20480)
+parser.add_argument("-t", "--tasks", help="Analysis Tasks to run.", type=dict, default=1024)
+parser.add_argument("-p", "--pitchmethod", help="Pitch method to use for analysis.", type=str, default='hps')
+parser.add_argument("-n", "--noruns", help="Number of runs to perform.", type=int, default=10)
+parser.add_argument("-c", "--channelcount", help="Number of channels to be analysed.", type=int, default=10)
 args = parser.parse_args()
 
 bands_of_interest = args.bands
 sampling_rate = args.samplingrate
 frames_per_sample = args.framespersample
 frequency_resolution = args.frequencyresolution
+no_runs = args.noruns
+pitch_algorithm = args.pitchmethod
 stub_wave = arange(frames_per_sample, dtype=int16).tobytes()
 stub_count = frequency_resolution // frames_per_sample
 
@@ -68,7 +76,7 @@ class Tracker(object):
             pass
 
 tr = Tracker()
-config = configuration.Config(**{'bands': bands_of_interest, 'frames_per_sample': frames_per_sample})
+config = configuration.Config(**{'bands': bands_of_interest, 'frames_per_sample': frames_per_sample, 'pitch_algorithm': pitch_algorithm})
 config.set_source({'channels': 1, 'rate': sampling_rate})
 root = hierarchy.new_hierarchy(config)
 dispatcher.connect(tr.set_switch, sender=0)
@@ -94,4 +102,4 @@ def profile_hierarchy(number):
         tr.store_times(start_time)
     tr.print_times()
 
-profile_hierarchy(10)
+profile_hierarchy(no_runs)

--- a/rtma-profiler.py
+++ b/rtma-profiler.py
@@ -109,11 +109,11 @@ CONFIG.set_source(
     {'channels': channel_count,
      'rate': sampling_rate
      })
-ROOT = hierarchy.new_hierarchy(CONFIG)
+ROOT = hierarchy.Hierarchy(CONFIG, [])
 dispatcher.connect(TR.set_switch, sender=0)
 for _ in range(stub_count):
     # As some tasks have a threshold before running, we need to feed them a couple of stubs.
-    ROOT.queue.put(frombuffer(stub_wave, dtype=int16))
+    ROOT.put(frombuffer(stub_wave, dtype=int16))
 TR.wait_for_signals()
 
 
@@ -130,7 +130,7 @@ def profile_hierarchy(number):
         TR.reset_tracker()
         start_time = time.time()
         # The root conversion time is taken into account.
-        ROOT.queue.put(frombuffer(stub_wave, dtype=int16))
+        ROOT.put(frombuffer(stub_wave, dtype=int16))
         TR.wait_for_signals()
         TR.store_times(start_time)
     TR.print_times()

--- a/rtma-profiler.py
+++ b/rtma-profiler.py
@@ -2,14 +2,16 @@
 
     This module is a commandline script, which can run the library tasks in a sandboxed setting.
 """
-from rtmaii import hierarchy, configuration
-from numpy import arange, sin, pi, ndarray, int16, frombuffer
-from pydispatch import dispatcher
 import argparse
 import time
 import statistics
+from rtmaii import hierarchy, configuration
+from numpy import arange, int16, frombuffer
+from pydispatch import dispatcher
 
-parser = argparse.ArgumentParser(description="Benchmark each task based on configuration options used in a sandbox simulation.")
+PARSER = argparse.ArgumentParser(
+    description="Benchmark each task based on configuration options used in a sandbox simulation."
+    )
 
 ## DEFAULTS ##
 BANDS = {
@@ -22,23 +24,43 @@ BANDS = {
     "brilliance":[6000, 20000]
 }
 
-parser.add_argument("-b", "--bands", help="Frequency bands to analyse as a dictionary.", type=dict, default=BANDS)
-parser.add_argument("-s", "--samplingrate", help="Sampling rate in Hertz, i.e. 44100", type=int, default=44100)
-parser.add_argument("-f", "--framespersample", help="Frames per buffer sample, default is 1024", type=int, default=1024)
-parser.add_argument("-r", "--frequencyresolution", help="Resolution of signal before performing frequency analysis. Default is 20480.", type=int, default=20480)
-parser.add_argument("-t", "--tasks", help="Analysis Tasks to run.", type=dict, default=1024)
-parser.add_argument("-p", "--pitchmethod", help="Pitch method to use for analysis.", type=str, default='hps')
-parser.add_argument("-n", "--noruns", help="Number of runs to perform.", type=int, default=10)
-parser.add_argument("-c", "--channelcount", help="Number of channels to be analysed.", type=int, default=10)
-args = parser.parse_args()
+PARSER.add_argument("-b", "--bands",
+                    help="Frequency bands to analyse as a dictionary.",
+                    type=dict, default=BANDS)
+PARSER.add_argument("-s", "--samplingrate",
+                    help="Sampling rate in Hertz, i.e. 44100",
+                    type=int, default=44100)
+PARSER.add_argument("-f", "--framespersample",
+                    help="Frames per buffer sample, default is 1024",
+                    type=int, default=1024)
+PARSER.add_argument("-r", "--frequencyresolution",
+                    help="Resolution of signal before performing frequency analysis. Default is 20480.",
+                    type=int, default=20480)
+PARSER.add_argument("-t", "--tasks", help="Analysis Tasks to run.",
+                    type=dict, default=1024)
+PARSER.add_argument("-p", "--pitchmethod",
+                    help="Pitch method to use for analysis.",
+                    type=str, default='hps')
+PARSER.add_argument("-n", "--noruns",
+                    help="Number of runs to perform.",
+                    type=int, default=10)
+PARSER.add_argument("-c", "--channelcount",
+                    help="Number of channels to mimic being analysed.",
+                    type=int, default=1)
+PARSER.add_argument("-m", "--mergechannels",
+                    help="Whether channel data should be analysed as one channel.",
+                    type=bool, default=True)
+ARGS = PARSER.parse_args()
 
-bands_of_interest = args.bands
-sampling_rate = args.samplingrate
-frames_per_sample = args.framespersample
-frequency_resolution = args.frequencyresolution
-no_runs = args.noruns
-pitch_algorithm = args.pitchmethod
-stub_wave = arange(frames_per_sample, dtype=int16).tobytes()
+bands_of_interest = ARGS.bands
+sampling_rate = ARGS.samplingrate
+frames_per_sample = ARGS.framespersample
+frequency_resolution = ARGS.frequencyresolution
+no_runs = ARGS.noruns
+pitch_algorithm = ARGS.pitchmethod
+channel_count = ARGS.channelcount
+merge_channels = ARGS.mergechannels
+stub_wave = arange(frames_per_sample * channel_count, dtype=int16).tobytes()
 stub_count = frequency_resolution // frames_per_sample
 
 class Tracker(object):
@@ -62,29 +84,37 @@ class Tracker(object):
         self.tracker = self.reset.copy()
 
     def set_switch(self, data, **kwargs):
-        tr.tracker[kwargs['signal']] = time.time()
+        self.tracker[kwargs['signal']] = time.time()
 
     def print_times(self):
         for signal, times in self.time_taken.items():
-            print('{} retrieval benchmark (Average time taken for signal to reach endpoint.)'.format(signal))
+            print('{} Average Retrieval Benchmark '.format(signal))
             print('\tMEDIAN ', statistics.median(times))
             print('\tMEAN ', statistics.mean(times))
-            #print('\tSTDEV ', statistics.stdev(times))
+            print('\tSTDEV ', statistics.stdev(times))
 
     def wait_for_signals(self):
         while None in self.tracker.values():
             pass
 
-tr = Tracker()
-config = configuration.Config(**{'bands': bands_of_interest, 'frames_per_sample': frames_per_sample, 'pitch_algorithm': pitch_algorithm})
-config.set_source({'channels': 1, 'rate': sampling_rate})
-root = hierarchy.new_hierarchy(config)
-dispatcher.connect(tr.set_switch, sender=0)
-for i in range(stub_count + 1):
+TR = Tracker()
+CONFIG = configuration.Config(
+    **{'bands': bands_of_interest,
+       'frames_per_sample': frames_per_sample,
+       'pitch_algorithm': pitch_algorithm,
+       'merge_channels': merge_channels,
+      }
+    )
+CONFIG.set_source(
+    {'channels': channel_count,
+     'rate': sampling_rate
+     })
+ROOT = hierarchy.new_hierarchy(CONFIG)
+dispatcher.connect(TR.set_switch, sender=0)
+for _ in range(stub_count):
     # As some tasks have a threshold before running, we need to feed them a couple of stubs.
-    root.queue.put(frombuffer(stub_wave, dtype=int16))
-tr.wait_for_signals()
-time.sleep(1)
+    ROOT.queue.put(frombuffer(stub_wave, dtype=int16))
+TR.wait_for_signals()
 
 
 print('Config options used in this benchmark are:')
@@ -92,14 +122,17 @@ print('\tBands: {}'.format(bands_of_interest))
 print('\tSampling rate: {}'.format(sampling_rate))
 print('\tFrames per buffer: {}'.format(frames_per_sample))
 
-print('On average {} buffer samples will be retrieved from the audio source a second.'.format(sampling_rate // frames_per_sample))
+print('On average {} buffer samples will be retrieved from the audio source a second.'
+      .format(sampling_rate // frames_per_sample))
+
 def profile_hierarchy(number):
     for _ in range(number):
-        tr.reset_tracker()
+        TR.reset_tracker()
         start_time = time.time()
-        root.queue.put(frombuffer(stub_wave, dtype=int16)) # The root conversion time is taken into account.
-        tr.wait_for_signals()
-        tr.store_times(start_time)
-    tr.print_times()
+        # The root conversion time is taken into account.
+        ROOT.queue.put(frombuffer(stub_wave, dtype=int16))
+        TR.wait_for_signals()
+        TR.store_times(start_time)
+    TR.print_times()
 
 profile_hierarchy(no_runs)

--- a/rtma-profiler.py
+++ b/rtma-profiler.py
@@ -1,0 +1,97 @@
+from rtmaii import hierarchy, configuration
+from numpy import arange, sin, pi, ndarray, int16, frombuffer
+from pydispatch import dispatcher
+import argparse
+import time
+import statistics
+
+parser = argparse.ArgumentParser(description="Benchmark each task based on configuration options used.")
+
+## DEFAULTS ##
+BANDS = {
+    "sub-bass":[20, 60],
+    "bass":[60, 250],
+    "low-mid":[250, 500],
+    "mid":[500, 2000],
+    "upper-mid":[2000, 4000],
+    "presence":[4000, 6000],
+    "brilliance":[6000, 20000]
+}
+
+parser.add_argument("-b", "--bands", help="Frequency bands to analyse as a dictionary.", type=dict, default=BANDS)
+parser.add_argument("-s", "--samplingrate", help="Sampling rate in Hertz, i.e. 44100", type=int, default=44100)
+parser.add_argument("-f", "--framespersample", help="Frames per buffer sample, default is 1024", type=int, default=1024)
+parser.add_argument("-r", "--frequencyresolution", help="Frames per buffer sample, default is 1024", type=int, default=20480)
+parser.add_argument("-t", "--tasks", help="Frames per buffer sample, default is 1024", type=dict, default=1024)
+parser.add_argument("-p", "--pitchmethod", help="Frames per buffer sample, default is 1024", type=str, default='hps')
+args = parser.parse_args()
+
+bands_of_interest = args.bands
+sampling_rate = args.samplingrate
+frames_per_sample = args.framespersample
+frequency_resolution = args.frequencyresolution
+stub_wave = arange(frames_per_sample, dtype=int16).tobytes()
+stub_count = frequency_resolution // frames_per_sample
+
+class Tracker(object):
+    def __init__(self):
+        self.reset = {
+            'pitch': None,
+            'note': None,
+            'bands': None,
+            'spectrum': None,
+            'signal': None,
+            'bpm': None
+        }
+        self.tracker = self.reset.copy()
+        self.time_taken = {key: [] for key, _ in self.reset.items()}
+
+    def store_times(self, start_time):
+        for signal, end_time in self.tracker.items():
+            self.time_taken[signal].append(end_time-start_time)
+
+    def reset_tracker(self):
+        self.tracker = self.reset.copy()
+
+    def set_switch(self, data, **kwargs):
+        tr.tracker[kwargs['signal']] = time.time()
+
+    def print_times(self):
+        for signal, times in self.time_taken.items():
+            print('{} retrieval benchmark (Average time taken for signal to reach endpoint.)'.format(signal))
+            print('\tMEDIAN ', statistics.median(times))
+            print('\tMEAN ', statistics.mean(times))
+            #print('\tSTDEV ', statistics.stdev(times))
+
+    def wait_for_signals(self):
+        while None in self.tracker.values():
+            pass
+
+tr = Tracker()
+config = configuration.Config(**{'bands': bands_of_interest, 'frames_per_sample': frames_per_sample})
+config.set_source({'channels': 1, 'rate': sampling_rate})
+root = hierarchy.new_hierarchy(config)
+dispatcher.connect(tr.set_switch, sender=0)
+for i in range(stub_count + 1):
+    # As some tasks have a threshold before running, we need to feed them a couple of stubs.
+    root.queue.put(frombuffer(stub_wave, dtype=int16))
+tr.wait_for_signals()
+time.sleep(1)
+
+
+print('Config options used in this benchmark are:')
+print('\tBands: {}'.format(bands_of_interest))
+print('\tSampling rate: {}'.format(sampling_rate))
+print('\tFrames per buffer: {}'.format(frames_per_sample))
+
+print('On average {} buffer samples will be retrieved from the audio source a second.'.format(sampling_rate // frames_per_sample))
+def profile_hierarchy(number):
+    for _ in range(number):
+        tr.reset_tracker()
+        start_time = time.time()
+        root.queue.put(frombuffer(stub_wave, dtype=int16)) # The root conversion time is taken into account.
+        tr.wait_for_signals()
+        tr.store_times(start_time)
+    tr.print_times()
+
+profile_hierarchy(10)

--- a/rtmaii/configuration.py
+++ b/rtmaii/configuration.py
@@ -78,7 +78,7 @@ class Config(object):
                 - See the base config class for possible config settings.
         """
         for key, value in kwargs.items():
-            if hasattr(self.settings, key):
+            if key in self.settings:
                 self.settings[key] = value
             else:
                 raise KeyError("{} is not a valid configuration setting".format(key))

--- a/rtmaii/coordinator.py
+++ b/rtmaii/coordinator.py
@@ -118,10 +118,10 @@ class FrequencyCoordinator(Coordinator):
             signal.extend(self.queue.get_all())
 
         while True:
-            data = self.queue.get_all()
-            signal = signal[len(data):]
-            signal.extend(data)
+            signal = signal[-frequency_resolution:]
             self.message_peers(signal)
+            data = self.queue.get_all()
+            signal.extend(data)
 
 class SpectrumCoordinator(Coordinator):
     """ Spectrum coordinator responsible for creating spectrum data and transmitting to dependants.


### PR DESCRIPTION
This PR adds a new rtma-profiler.py script, which can be used to benchmark how long on average each signal (event) takes to be returned.

As this is a cmdline script, users will be able to run our library in a sandbox with a dummy signal, testing how long on their machine it takes for the dummy signal to reach an endpoint. They can then run the script with different parameters to configure the library to their liking testing each type of configuration.

![image](https://user-images.githubusercontent.com/29373199/37646721-4a0c9ac2-2c22-11e8-9711-3fa6d0dea823.png)
